### PR TITLE
ops(benchmark): baseline latency/accuracy/resource matrix

### DIFF
--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -1,0 +1,6 @@
+# Benchmark-only dependencies (not required for main christopher.py operation)
+# Install: pip install -r benchmarks/requirements.txt
+pyyaml>=6.0
+psutil>=5.9
+requests>=2.28        # already in christopher_requirements.txt; listed here for completeness
+python-dotenv>=1.0    # already in christopher_requirements.txt

--- a/benchmarks/results/baseline_2026-04-27.md
+++ b/benchmarks/results/baseline_2026-04-27.md
@@ -1,0 +1,125 @@
+# Christopher-AI — Baseline Benchmark Matrix
+
+**Issue:** [#5 ops(benchmark): baseline latency/accuracy/resource matrix](https://github.com/JRM-FusionAL/Christopher-AI/issues/5)  
+**Status:** awaiting first run on reference hardware  
+**Reproduce:** see [Reproduction](#reproduction) section below  
+
+---
+
+## Environment Context
+
+| Property | Value |
+|----------|-------|
+| Hardware | Intel Core i5-7300HQ · NVIDIA GTX 1050 Ti 4 GB VRAM |
+| OS / Runtime | Windows 11 + WSL2 Ubuntu (PulseAudio bridge for voice) |
+| llama.cpp | build from source (main branch) |
+| Whisper model | ggml-base.en (ASR, not measured in LLM benchmarks) |
+| Python | 3.11+ |
+| Benchmark script | `benchmarks/run_benchmark.py` |
+| Scenarios file | `benchmarks/scenarios.yaml` |
+| Runs per cell | 3 (configurable via `--runs`) |
+| Temperature | 0.1 (fixed for reproducibility) |
+
+---
+
+## Model Profiles Under Test
+
+| Profile key | Model | GPU layers (ngl) | Context (ctx) | Est. VRAM |
+|-------------|-------|-----------------|---------------|-----------|
+| `llama32-3b` | Llama 3.2 3B Instruct Q4_K_M | 99 (full GPU) | 2048 | ~2.0 GB |
+| `qwen25-3b` | Qwen2.5 3B Instruct Q4_K_M | 99 (full GPU) | 2048 | ~2.0 GB |
+| `mistral-7b` | Mistral 7B Instruct v0.2 Q4_K_M | 28 (partial — 4 GB limit) | 512 | ~3.8 GB |
+
+---
+
+## Benchmark Scenarios
+
+| ID | Label | Prompt (excerpt) | Max tokens | Quality rubric |
+|----|-------|-----------------|------------|----------------|
+| `short-factual` | Short Factual | "What is the capital of France? …" | 40 | Contains "Paris" |
+| `medium-explanation` | Medium Explanation | "In 3–4 sentences, explain transformer … attention …" | 160 | ≥3 sentences, mentions attention |
+| `complex-list` | Complex Structured List | "List exactly 3 advantages and 3 disadvantages …" | 320 | Both sections present, 3 items each |
+
+Full prompts and rubrics: [`benchmarks/scenarios.yaml`](../scenarios.yaml)
+
+---
+
+## Results Matrix
+
+> **Note:** Cells show `[pending]` until the benchmark is run on the reference hardware.
+> Run `benchmarks/run_benchmark.py` and paste the output here.
+
+### Short Factual
+
+| Profile | Avg (s) | Min (s) | Max (s) | Tokens | Tok/s | VRAM (MB) | RSS (MB) |
+|---------|--------|---------|---------|--------|-------|-----------|----------|
+| llama32-3b | [pending] | — | — | — | — | — | — |
+| qwen25-3b | [pending] | — | — | — | — | — | — |
+| mistral-7b | [pending] | — | — | — | — | — | — |
+
+### Medium Explanation
+
+| Profile | Avg (s) | Min (s) | Max (s) | Tokens | Tok/s | VRAM (MB) | RSS (MB) |
+|---------|--------|---------|---------|--------|-------|-----------|----------|
+| llama32-3b | [pending] | — | — | — | — | — | — |
+| qwen25-3b | [pending] | — | — | — | — | — | — |
+| mistral-7b | [pending] | — | — | — | — | — | — |
+
+### Complex Structured List
+
+| Profile | Avg (s) | Min (s) | Max (s) | Tokens | Tok/s | VRAM (MB) | RSS (MB) |
+|---------|--------|---------|---------|--------|-------|-----------|----------|
+| llama32-3b | [pending] | — | — | — | — | — | — |
+| qwen25-3b | [pending] | — | — | — | — | — | — |
+| mistral-7b | [pending] | — | — | — | — | — | — |
+
+---
+
+## Reproduction
+
+```bash
+# Install benchmark deps (once)
+pip install -r benchmarks/requirements.txt
+
+# ── Profile 1: llama32-3b ──────────────────────────────────────────────────
+python3 christopher.py --chat --no-kb --model-profile llama32-3b
+# (wait for "Christopher is ready", then in a second terminal:)
+python3 benchmarks/run_benchmark.py \
+    --profile llama32-3b --runs 3 \
+    --output benchmarks/results/baseline_$(date +%Y-%m-%d).md
+
+# ── Profile 2: qwen25-3b ───────────────────────────────────────────────────
+# Ctrl-C christopher, then:
+python3 christopher.py --chat --no-kb --model-profile qwen25-3b
+python3 benchmarks/run_benchmark.py \
+    --profile qwen25-3b --runs 3 --append \
+    --output benchmarks/results/baseline_$(date +%Y-%m-%d).md
+
+# ── Profile 3: mistral-7b ──────────────────────────────────────────────────
+python3 christopher.py --chat --no-kb --model-profile mistral-7b
+python3 benchmarks/run_benchmark.py \
+    --profile mistral-7b --runs 3 --append \
+    --output benchmarks/results/baseline_$(date +%Y-%m-%d).md
+```
+
+The output file will contain three appended sections — one per profile — each
+with the full results table and sample responses.
+
+---
+
+## Pilot Sizing Notes
+
+These benchmarks are intended to answer: *"What latency and resource envelope
+should the pilot team expect?"*
+
+Expected latency ranges on GTX 1050 Ti 4 GB (estimates — replace with actuals):
+
+| Profile | Short resp. | Medium resp. | Memory pressure |
+|---------|-------------|--------------|-----------------|
+| llama32-3b | ~1–3 s | ~4–8 s | Low (fits fully in VRAM) |
+| qwen25-3b | ~1–3 s | ~4–8 s | Low (fits fully in VRAM) |
+| mistral-7b | ~6–15 s | ~18–35 s | High (partial CPU offload) |
+
+**Recommendation for pilot:** start with `llama32-3b` or `qwen25-3b` for
+interactive latency targets. Use `mistral-7b` only when output quality
+justifies the longer wait.

--- a/benchmarks/run_benchmark.py
+++ b/benchmarks/run_benchmark.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""
+benchmarks/run_benchmark.py — Christopher-AI baseline benchmark runner
+
+Connects to a running llama-server, runs every scenario from scenarios.yaml
+across the model currently loaded, and writes a Markdown results matrix.
+
+Prerequisites
+─────────────
+1. Start Christopher (which auto-starts llama-server):
+     python3 christopher.py --chat --no-kb
+   Wait for "Christopher is ready."
+
+2. In a separate terminal (or after Ctrl-C if using --no-server externally):
+     python3 benchmarks/run_benchmark.py --profile llama32-3b
+
+For a full three-profile comparison run each profile in sequence:
+     python3 benchmarks/run_benchmark.py --profile llama32-3b \\
+         --output benchmarks/results/baseline_$(date +%Y-%m-%d).md
+   # restart christopher with qwen25-3b, then:
+     python3 benchmarks/run_benchmark.py --profile qwen25-3b \\
+         --output benchmarks/results/baseline_$(date +%Y-%m-%d).md --append
+   # restart christopher with mistral-7b, then:
+     python3 benchmarks/run_benchmark.py --profile mistral-7b \\
+         --output benchmarks/results/baseline_$(date +%Y-%m-%d).md --append
+
+See benchmarks/scenarios.yaml to add or modify scenarios.
+"""
+
+import argparse
+import json
+import os
+import platform
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    import requests
+except ImportError:
+    print("ERROR: requests not installed.  Run: pip install requests")
+    sys.exit(1)
+
+try:
+    import yaml
+except ImportError:
+    print("ERROR: pyyaml not installed.  Run: pip install pyyaml")
+    sys.exit(1)
+
+try:
+    import psutil
+    _HAS_PSUTIL = True
+except ImportError:
+    _HAS_PSUTIL = False
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCENARIOS_FILE = Path(__file__).resolve().parent / "scenarios.yaml"
+SYSTEM_PROMPT = "You are Christopher. Be brief and direct."
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def load_scenarios(path: Path, ids: list[str] | None = None) -> list[dict]:
+    with open(path) as fh:
+        data = yaml.safe_load(fh)
+    scenarios = data["scenarios"]
+    if ids:
+        scenarios = [s for s in scenarios if s["id"] in ids]
+    return scenarios
+
+
+def server_reachable(base_url: str, timeout: int = 5) -> bool:
+    for path in ("/health", "/v1/models"):
+        try:
+            r = requests.get(f"{base_url}{path}", timeout=timeout)
+            if r.status_code < 500:
+                return True
+        except Exception:
+            pass
+    return False
+
+
+def chat_completion(base_url: str, prompt: str, max_tokens: int) -> tuple[str, int]:
+    """Returns (response_text, completion_token_count)."""
+    payload = {
+        "messages": [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": prompt},
+        ],
+        "max_tokens": max_tokens,
+        "temperature": 0.1,
+        "top_p": 0.9,
+    }
+    r = requests.post(
+        f"{base_url}/v1/chat/completions",
+        json=payload,
+        headers={"Content-Type": "application/json"},
+        timeout=180,
+    )
+    r.raise_for_status()
+    data = r.json()
+    text = data["choices"][0]["message"]["content"].strip()
+    tokens = data.get("usage", {}).get("completion_tokens", 0)
+    return text, tokens
+
+
+def sample_vram_mb() -> int | None:
+    """Read GPU VRAM in use via nvidia-smi (best-effort)."""
+    try:
+        out = subprocess.check_output(
+            ["nvidia-smi", "--query-gpu=memory.used", "--format=csv,noheader,nounits"],
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        )
+        return int(out.decode().strip().split("\n")[0])
+    except Exception:
+        return None
+
+
+def sample_llama_rss_mb() -> int | None:
+    """RSS of the llama-server process (best-effort, requires psutil)."""
+    if not _HAS_PSUTIL:
+        return None
+    try:
+        for proc in psutil.process_iter(["name", "memory_info"]):
+            name = (proc.info.get("name") or "").lower()
+            if "llama" in name or "llama-server" in name:
+                return proc.info["memory_info"].rss // (1024 * 1024)
+    except Exception:
+        pass
+    return None
+
+
+def get_gpu_label() -> str:
+    try:
+        out = subprocess.check_output(
+            ["nvidia-smi", "--query-gpu=name,memory.total", "--format=csv,noheader"],
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        )
+        return out.decode().strip().split("\n")[0]
+    except Exception:
+        return "N/A"
+
+
+def get_env_ngl_ctx() -> tuple[str, str]:
+    env_file = REPO_ROOT / ".env"
+    if not env_file.exists():
+        return "default", "default"
+    try:
+        from dotenv import dotenv_values
+        env = dotenv_values(env_file)
+        return env.get("LLAMA_NGL", "default"), env.get("LLAMA_CTX", "default")
+    except Exception:
+        return "default", "default"
+
+
+# ── Core benchmark ────────────────────────────────────────────────────────────
+
+def run_scenario(base_url: str, scenario: dict, runs: int) -> dict:
+    latencies: list[float] = []
+    token_counts: list[int] = []
+    responses: list[str] = []
+    vram_readings: list[int] = []
+
+    for _ in range(runs):
+        t0 = time.perf_counter()
+        text, tokens = chat_completion(base_url, scenario["prompt"], scenario["max_tokens"])
+        elapsed = time.perf_counter() - t0
+        latencies.append(elapsed)
+        token_counts.append(tokens)
+        responses.append(text)
+        v = sample_vram_mb()
+        if v is not None:
+            vram_readings.append(v)
+
+    avg_lat = sum(latencies) / len(latencies)
+    avg_tok = sum(token_counts) / len(token_counts) if token_counts else 0
+    tps = avg_tok / avg_lat if avg_lat > 0 and avg_tok > 0 else 0.0
+
+    return {
+        "avg_latency": avg_lat,
+        "min_latency": min(latencies),
+        "max_latency": max(latencies),
+        "avg_tokens": avg_tok,
+        "tok_per_sec": tps,
+        "vram_mb": max(vram_readings) if vram_readings else None,
+        "rss_mb": sample_llama_rss_mb(),
+        "sample_response": responses[-1][:140],
+    }
+
+
+# ── Markdown output ───────────────────────────────────────────────────────────
+
+def _fmt(value: float | None, fmt: str = ".2f") -> str:
+    return f"{value:{fmt}}" if value is not None else "—"
+
+
+def _fmt_int(value: float | None) -> str:
+    return f"{int(value)}" if value is not None else "—"
+
+
+def render_markdown(
+    profile: str,
+    results: dict[str, dict],
+    scenarios: list[dict],
+    runs: int,
+    base_url: str,
+) -> str:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    ngl, ctx = get_env_ngl_ctx()
+    gpu = get_gpu_label()
+    lines: list[str] = []
+
+    lines += [
+        f"# Christopher-AI Benchmark — {profile}",
+        "",
+        f"**Generated:** {now}  ",
+        f"**Platform:** {platform.platform()}  ",
+        f"**GPU:** {gpu}  ",
+        f"**Profile:** {profile} | GPU layers (ngl): {ngl} | Context (ctx): {ctx}  ",
+        f"**Runs per scenario:** {runs}  ",
+        f"**Temperature:** 0.1 (fixed for reproducibility)  ",
+        f"**Server:** {base_url}  ",
+        "",
+        "---",
+        "",
+        "## Results",
+        "",
+        "| Scenario | Avg (s) | Min (s) | Max (s) | Tokens | Tok/s | VRAM (MB) | RSS (MB) |",
+        "|----------|--------|---------|---------|--------|-------|-----------|----------|",
+    ]
+
+    for s in scenarios:
+        cell = results.get(s["id"])
+        if cell is None:
+            lines.append(f"| {s['label']} | FAILED | — | — | — | — | — | — |")
+        else:
+            vram = _fmt_int(cell["vram_mb"])
+            rss = _fmt_int(cell["rss_mb"])
+            lines.append(
+                f"| {s['label']}"
+                f" | {_fmt(cell['avg_latency'])}"
+                f" | {_fmt(cell['min_latency'])}"
+                f" | {_fmt(cell['max_latency'])}"
+                f" | {_fmt_int(cell['avg_tokens'])}"
+                f" | {_fmt(cell['tok_per_sec'], '.1f')}"
+                f" | {vram}"
+                f" | {rss} |"
+            )
+
+    lines += [
+        "",
+        "## Sample Responses (last run)",
+        "",
+    ]
+    for s in scenarios:
+        cell = results.get(s["id"])
+        if cell:
+            lines.append(f"**{s['label']}** — _{s['quality_rubric']}_")
+            lines.append(f"> {cell['sample_response']}")
+            lines.append("")
+
+    lines += [
+        "---",
+        "",
+        "## Reproduction",
+        "",
+        "```bash",
+        "# Start Christopher (launches llama-server automatically)",
+        f"python3 christopher.py --chat --no-kb --model-profile {profile}",
+        "",
+        "# In a separate terminal, run the benchmark",
+        f"python3 benchmarks/run_benchmark.py --profile {profile} \\",
+        f"    --server-url {base_url} --runs {runs} \\",
+        f"    --output benchmarks/results/baseline_{profile}_$(date +%Y-%m-%d).md",
+        "```",
+        "",
+        "Scenarios are defined in `benchmarks/scenarios.yaml` and can be extended.",
+    ]
+
+    return "\n".join(lines) + "\n"
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Christopher-AI baseline benchmark runner",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--profile", default="llama32-3b",
+        help="Label for the currently loaded model profile (default: llama32-3b)",
+    )
+    parser.add_argument(
+        "--server-url", default="http://127.0.0.1:8080",
+        help="llama-server base URL (default: http://127.0.0.1:8080)",
+    )
+    parser.add_argument(
+        "--runs", type=int, default=3,
+        help="Inference runs per scenario (default: 3)",
+    )
+    parser.add_argument(
+        "--scenarios", nargs="+", default=None,
+        help="Scenario IDs to run (default: all). e.g. --scenarios short-factual complex-list",
+    )
+    parser.add_argument(
+        "--scenarios-file", default=str(SCENARIOS_FILE),
+        help="Path to scenarios.yaml",
+    )
+    parser.add_argument(
+        "--output", default=None,
+        help="Write Markdown results to this file (default: print to stdout)",
+    )
+    parser.add_argument(
+        "--append", action="store_true",
+        help="Append to --output instead of overwriting",
+    )
+    args = parser.parse_args()
+
+    scenarios = load_scenarios(Path(args.scenarios_file), ids=args.scenarios)
+    if not scenarios:
+        print("ERROR: no scenarios matched. Check --scenarios or scenarios.yaml")
+        sys.exit(1)
+
+    if not server_reachable(args.server_url):
+        print(f"ERROR: llama-server not reachable at {args.server_url}")
+        print("Start Christopher first:  python3 christopher.py --chat --no-kb")
+        sys.exit(1)
+
+    print(f"Profile : {args.profile}")
+    print(f"Server  : {args.server_url}")
+    print(f"Runs    : {args.runs} per scenario")
+    print(f"Scenarios: {[s['id'] for s in scenarios]}")
+    print()
+
+    results: dict[str, dict | None] = {}
+    for s in scenarios:
+        print(f"  [{s['id']}] ...", end=" ", flush=True)
+        try:
+            cell = run_scenario(args.server_url, s, args.runs)
+            results[s["id"]] = cell
+            print(
+                f"avg={cell['avg_latency']:.2f}s  "
+                f"tok/s={cell['tok_per_sec']:.1f}  "
+                f"tokens={cell['avg_tokens']:.0f}"
+            )
+        except Exception as exc:
+            results[s["id"]] = None
+            print(f"FAILED: {exc}")
+
+    print()
+    md = render_markdown(args.profile, results, scenarios, args.runs, args.server_url)
+
+    if args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        mode = "a" if args.append else "w"
+        with open(out_path, mode) as fh:
+            if args.append:
+                fh.write("\n\n---\n\n")
+            fh.write(md)
+        print(f"Results written to {out_path}")
+    else:
+        print(md)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/scenarios.yaml
+++ b/benchmarks/scenarios.yaml
@@ -1,0 +1,51 @@
+# Christopher-AI Baseline Benchmark Scenarios
+#
+# Three workload profiles covering the latency/throughput spectrum expected
+# during pilot use. Each scenario is independently repeatable.
+#
+# Fields:
+#   id           - unique slug used in CLI args and result file keys
+#   label        - human-readable name for tables
+#   description  - what aspect of the pipeline this exercises
+#   prompt       - exact prompt sent (temperature 0.1 for reproducibility)
+#   max_tokens   - hard ceiling passed to /v1/chat/completions
+#   quality_rubric - pass/fail heuristic reviewers check against sample output
+
+scenarios:
+  - id: short-factual
+    label: "Short Factual"
+    description: >
+      Single-question factual lookup expecting a 1-2 sentence answer.
+      Exercises cold-start token throughput and first-token latency.
+    prompt: "What is the capital of France? Answer in one sentence."
+    max_tokens: 40
+    quality_rubric: "Response contains the word 'Paris'"
+
+  - id: medium-explanation
+    label: "Medium Explanation"
+    description: >
+      Conceptual explanation requiring 3-4 coherent sentences.
+      Exercises sustained generation quality and mid-range context use.
+    prompt: >
+      In 3 to 4 sentences, explain what a transformer neural network is
+      and why the attention mechanism is important.
+    max_tokens: 160
+    quality_rubric: >
+      Mentions attention mechanism; contains at least 3 sentences;
+      no obvious mid-sentence truncation
+
+  - id: complex-list
+    label: "Complex Structured List"
+    description: >
+      Multi-point structured reasoning response requiring format adherence.
+      Exercises longer output coherence and instruction-following under
+      a token budget that fits within the mistral-7b context limit.
+    prompt: >
+      List exactly 3 advantages and 3 disadvantages of running AI models
+      locally on your own hardware instead of using cloud APIs.
+      Format each group as a numbered list with a bold heading.
+    max_tokens: 320
+    quality_rubric: >
+      Contains both an advantages and a disadvantages section;
+      each section has exactly 3 numbered items;
+      covers at least one of: privacy, cost, latency, control


### PR DESCRIPTION
Closes #5

## Summary

- Adds `benchmarks/scenarios.yaml` — three documented, repeatable workload scenarios (short-factual, medium-explanation, complex-list) covering the latency/throughput spectrum expected during pilot use
- Adds `benchmarks/run_benchmark.py` — standalone runner that connects to a running llama-server, times N inference runs per scenario, captures token throughput + VRAM + process RSS, and emits a Markdown results matrix
- Adds `benchmarks/requirements.txt` — `pyyaml` + `psutil` deps needed by the script
- Adds `benchmarks/results/baseline_2026-04-27.md` — matrix template with environment context (GTX 1050 Ti reference hardware), pilot sizing guidance, and step-by-step reproduction instructions for all three model profiles

## Acceptance criteria

- [x] Benchmark scenarios are documented and repeatable (`scenarios.yaml` + `--scenarios-file` flag)
- [x] Matrix includes at least 3 representative workload profiles (short-factual / medium-explanation / complex-list)
- [x] Results include environment context (hardware table + ngl/ctx columns in output)

## Test plan

- [ ] `pip install -r benchmarks/requirements.txt`
- [ ] Start Christopher with `llama32-3b`: `python3 christopher.py --chat --no-kb --model-profile llama32-3b`
- [ ] Run: `python3 benchmarks/run_benchmark.py --profile llama32-3b --runs 3`
- [ ] Confirm Markdown table is printed with latency, tok/s, and VRAM columns populated
- [ ] Repeat for `qwen25-3b` and `mistral-7b` profiles
- [ ] Save combined output to `benchmarks/results/baseline_2026-04-27.md` using `--output` + `--append`

https://claude.ai/code/session_016z8yAsrn12z6qmuYF8Pkac

---
_Generated by [Claude Code](https://claude.ai/code/session_016z8yAsrn12z6qmuYF8Pkac)_