### PR TITLE
fix: install scipy for CI test compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,5 +19,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           if [ -f christopher_requirements.txt ]; then pip install -r christopher_requirements.txt; fi
+          # test_logic.py imports from christopher.py which imports scipy at module level
+          pip install scipy 2>/dev/null || true
       - name: Run logic tests
         run: python test_logic.py


### PR DESCRIPTION
test_logic.py imports from christopher.py which imports scipy at module level. Adding scipy to CI install step.