### PR TITLE
Bump anthropic SDK to 0.118.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ python-dotenv==1.2.2
 requests==2.34.2
 scipy==1.18.0
 httpx==0.28.1
-anthropic==0.117.0
+anthropic==0.118.0
 pydantic==2.13.4
 mcp[cli]==1.28.1
 


### PR DESCRIPTION
## Summary
- Bumped `anthropic` from 0.117.0 to 0.118.0 in `requirements.txt`

Found by a scheduled dependency audit across all connected repos. No security advisories were found for this repo's dependencies (requests, fastapi, uvicorn, httpx, anthropic, pydantic, mcp[cli] are all current or were already patched against known CVEs). This was the only outstanding update.

## Test plan
- [ ] Routine SDK patch bump — no code changes required; verify `pip install -r requirements.txt` resolves cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNN3U7Mjk4Vd2pgXuYpQ6E

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNN3U7Mjk4Vd2pgXuYpQ6E)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What
Update the `anthropic` dependency to version `0.118.0`.

## Changes
- `requirements.txt`: Bump `anthropic` from `0.117.0` to `0.118.0`.

## Dependencies
- Updated package: `anthropic==0.118.0`

## Testing
- Run `pip install -r requirements.txt` and confirm successful resolution.

## Contributors
Contributor line counts were not available from the repository metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->