### PR TITLE
fix(deps): carry CVE floor pins into christopher_requirements.txt

### DIFF
--- a/christopher_requirements.txt
+++ b/christopher_requirements.txt
@@ -6,3 +6,9 @@ requests==2.34.2
 python-dotenv==1.2.2
 fastapi==0.141.1
 uvicorn==0.52.1
+
+# Security: pin transitive deps with known HIGH CVEs to patched versions (mirrors requirements.txt)
+setuptools>=83.0.0     # CVE-2026-23949 + CVE-2026-24049: setuptools<82.0.1 vendors jaraco.context 5.3.0 and wheel 0.45.1
+jaraco.context>=6.1.2  # CVE-2026-23949 (path traversal); fixed in 6.1.0
+wheel>=0.47.0          # CVE-2026-24049 (arbitrary file permission via path traversal); fixed in 0.46.2
+starlette>=1.4.1       # CVE-2026-48710 "BadHost": transitive dep of fastapi, unpinned otherwise; host-header auth bypass fixed in 1.0.1


### PR DESCRIPTION
## Summary

Fixes found by a scheduled dependency audit (2026-08-12) covering all JRM-FusionAL repos.

`requirements.txt` carries four explicit floor-pins added specifically to close known CVEs: setuptools/jaraco.context/wheel (CVE-2026-23949, CVE-2026-24049 — path traversal / arbitrary file permission) and starlette (CVE-2026-48710 "BadHost" — host-header auth bypass, pulled in transitively via fastapi).

**`christopher_requirements.txt` — the file its own header comment says gets installed "in WSL Ubuntu under `/home/oledad`" — had none of those four pins.** It pins `fastapi==0.141.1` with no starlette floor, so that host wasn't guaranteed to resolve a patched starlette (or patched setuptools/wheel) even though the main `requirements.txt` was already defended. Added the same four lines here.

## Explicitly NOT done here
- Didn't add `scipy`/`httpx`/`anthropic`/`pydantic`/`mcp` to `christopher_requirements.txt` — per this repo's own CLAUDE.md, that file is intentionally minimal ("this is a local tool, not a service. No AI API clients needed"), so those omissions look deliberate rather than a gap. Only the security floor-pins were added.

## Test plan
- [ ] `pip3 install -r christopher_requirements.txt` resolves cleanly in a clean WSL/Ubuntu venv
- [ ] `bash preflight_voice.sh` still passes

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqGPcV7UK5omxGSWxATgLD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What

Add security floor pins for the WSL Ubuntu voice-pipeline requirements.

## Changes

- Updated `christopher_requirements.txt`.
- Added minimum versions for `setuptools`, `jaraco.context`, `wheel`, and `starlette`.
- Addressed CVE-2026-23949, CVE-2026-24049, and CVE-2026-48710.

## Dependencies

- No new packages.
- Added four minimum-version package pins.
- No new environment variables.

## Testing

- Install `christopher_requirements.txt` in a clean WSL/Ubuntu virtual environment.
- Run `bash preflight_voice.sh`.

## Contributors

| Author | Lines added | Lines removed |
|---|---:|---:|
| Not specified | 6 | 0 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->